### PR TITLE
EG-3 provide explicitly named junit output

### DIFF
--- a/bin/exportClientTest.sh
+++ b/bin/exportClientTest.sh
@@ -21,14 +21,14 @@ echo "[info] ---------- use docker-compose run newman ----------"
 
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="registration" --iteration-data="data/exportClientData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/exportClient_registration_`date "+%Y%m%d-%H%M%S"`.xml"
 
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="registration_error_4xx" --iteration-data="data/exportClientData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/exportClient_registration4xx_`date "+%Y%m%d-%H%M%S"`.xml"
     
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="ping" --iteration-data="data/exportClientData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/exportClient_ping_`date "+%Y%m%d-%H%M%S"`.xml"
 
 echo "Info: Export-Client Test Completed."

--- a/bin/rulesengineTest.sh
+++ b/bin/rulesengineTest.sh
@@ -21,14 +21,14 @@ echo "[info] ---------- use docker-compose run newman ----------"
 
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="rules" --iteration-data="data/rulesengineData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/supportRulesengine_rules_`date "+%Y%m%d-%H%M%S"`.xml"
 
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="rules_error_5xx" --iteration-data="data/rulesengineData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/supportRulesengine_rules5xx_`date "+%Y%m%d-%H%M%S"`.xml"
 
 docker-compose run --rm postman run ${COLLECTION_PATH} \
     --folder="ping" --iteration-data="data/rulesengineData.json" --environment=${ENV_PATH} \
-    --reporters="junit,cli"
+    --reporters="junit,cli" --reporter-junit-export "newman/supportRulesengine_ping_`date "+%Y%m%d-%H%M%S"`.xml"
 
-echo "Info:Rulesengine Test Completed."
+echo "Info: Rulesengine Test Completed."


### PR DESCRIPTION
A quick update to name the junit output files so we can display them on the testing dashboard.